### PR TITLE
fix: fixing memory leak in mvp

### DIFF
--- a/app/src/main/java/com/arthurgonzaga/dictionary/ui/MainActivity.kt
+++ b/app/src/main/java/com/arthurgonzaga/dictionary/ui/MainActivity.kt
@@ -15,15 +15,18 @@ import java.util.concurrent.TimeUnit
 
 class MainActivity : AppCompatActivity(), MainContract.View {
 
-    var presenter: MainContract.Presenter = MainPresenter(this)
+    private var _presenter: MainContract.Presenter? = null
+    private val presenter get() = _presenter!!
 
     private lateinit var binding: ActivityMainBinding
 
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityMainBinding.inflate(LayoutInflater.from(this))
+        binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
+
+        _presenter = MainPresenter(this)
+
         setupEditTextListener()
     }
 
@@ -44,6 +47,11 @@ class MainActivity : AppCompatActivity(), MainContract.View {
     override fun showErrorSnackBar(message: String?) {
         val textId = if(message?.contains("404") == true) R.string.word_not_found else R.string.something_wrong
         Snackbar.make(binding.root, textId, Snackbar.LENGTH_SHORT).show()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        _presenter = null
     }
 
     companion object {


### PR DESCRIPTION
Esse é um problema comum na arquitetura mvp que precisa de atenção na sua implementação. Ao contrário do mvvm, no mvp o presenter possui uma referência a visualização (mesmo que tipada pelo contrato), e pela visualização também possuir uma referência do presenter aqui temos um memory leak. O problema aqui é que o garbage collection não vai conseguir limpar nenhum dos dois objetos porque sempre um vai estar apontando para o outro, o que pode ser um problema em aplicações grandes com muitas telas. A solução é usar o ciclo de vida da visualização pra eliminar a referência quando ela não for mais necessária.